### PR TITLE
MXC IPU: Replace wait_event with wait_event_interruptible

### DIFF
--- a/drivers/mxc/ipu3/ipu_device.c
+++ b/drivers/mxc/ipu3/ipu_device.c
@@ -3111,7 +3111,8 @@ static int ipu_task_thread(void *argv)
 		int split_parent;
 		int split_child;
 
-		wait_event(thread_waitq, find_task(&tsk, curr_thread_id));
+		if(wait_event_interruptible(thread_waitq, find_task(&tsk, curr_thread_id)))
+                  break;
 
 		if (!tsk) {
 			pr_err("thread:%d can not find task.\n",


### PR DESCRIPTION
Having the 4 IPU tasks blocked on wait_event artificially inflates the load average by 4. wait_event_interruptible should be an acceptable alternative.

-- Note from bill s --

I applied this patch based on the thread comment http://www.udoo.org/forum/viewtopic.php?f=2&t=149&start=10#p2044

On my quad, the cpu load is much lower and the system feels a lot more responsive now.

ubuntu@imx6-qsdl:~$ w
 16:36:16 up 5 min,  1 user,  load average: 0.10, 0.17, 0.09
USER     TTY      FROM              LOGIN@   IDLE   JCPU   PCPU WHAT
ubuntu   pts/0    192.168.1.213    16:31    0.00s  0.10s  0.04s w
